### PR TITLE
Refactor theme toggle to use class-based dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 </head>
 
 <body>
-  <div class="container active" id="container">
+  <div class="container" id="container">
 
     <!-- ====== HEADER ====== -->
     <header class="header">
@@ -35,7 +35,7 @@
         Alexandre
       </a>
 
-      <!-- ENVOLVENDO nav + toggle-icon -->
+      <!-- ENVOLVENDO nav + toggle-button -->
       <div class="nav-controls">
         <nav class="navbar" role="navigation" aria-label="Menu principal">
           <button class="menu-toggle" aria-label="Abrir menu">
@@ -50,9 +50,9 @@
           </div>
         </nav>
 
-        <div class="toggle-icon" aria-label="Alternar tema">
-          <i class="bx bx-moon"></i>
-        </div>
+        <button class="toggle-button" type="button" id="theme-toggle" aria-label="Ativar tema escuro" aria-pressed="false">
+          <i class="bx bx-moon" aria-hidden="true"></i>
+        </button>
       </div>
     </header>
 
@@ -70,8 +70,8 @@
             Focado em eficiência, valor real e impacto direto nos projetos.</p>
 
           <div class="social-media">
-            <a href="https://www.linkedin.com/in/alexandrearnoni" target="_blank" aria-label="LinkedIn"><i class="bx bxl-linkedin"></i></a>
-            <a href="https://github.com/alexarnoni" target="_blank" aria-label="GitHub"><i class="bx bxl-github"></i></a>
+            <a href="https://www.linkedin.com/in/alexandrearnoni" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><i class="bx bxl-linkedin"></i></a>
+            <a href="https://github.com/alexarnoni" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="bx bxl-github"></i></a>
           </div>
 
           <div class="dropdown">
@@ -172,7 +172,7 @@
               <div class="project-info">
                 <h3>EV+ Betting Bot</h3>
                 <p>Bot em Python que detecta valor esperado positivo (EV+) em apostas esportivas e envia alertas via Telegram.</p>
-                <a href="https://github.com/alexarnoni/TuringOdds" class="btn" target="_blank">Ver no GitHub</a>
+                <a href="https://github.com/alexarnoni/TuringOdds" class="btn" target="_blank" rel="noopener noreferrer">Ver no GitHub</a>
               </div>
             </div>
 
@@ -181,7 +181,7 @@
               <div class="project-info">
                 <h3>PlayMood</h3>
                 <p>Recomendador de playlists baseado em sentimento do usuário, integrando HuggingFace e Spotify API.</p>
-                <a href="https://github.com/alexarnoni/api_spotify_machineLearning" class="btn" target="_blank">Ver no GitHub</a>
+                <a href="https://github.com/alexarnoni/api_spotify_machineLearning" class="btn" target="_blank" rel="noopener noreferrer">Ver no GitHub</a>
               </div>
             </div>
 
@@ -190,7 +190,7 @@
               <div class="project-info">
                 <h3>Organizador Financeiro</h3>
                 <p>Dashboard web para controle de finanças pessoais com autenticação, gráficos e PostgreSQL integrado.</p>
-                <a href="https://github.com/alexarnoni/organizador-financeiro" class="btn" target="_blank">Ver no GitHub</a>
+                <a href="https://github.com/alexarnoni/organizador-financeiro" class="btn" target="_blank" rel="noopener noreferrer">Ver no GitHub</a>
               </div>
             </div>
 
@@ -205,8 +205,8 @@
           <p class="section-text">Quer conversar, colaborar ou tem uma oportunidade?</p>
           <div class="contact-info">
             <p><i class='bx bx-envelope'></i> <a href="mailto:alexandre.anf@gmail.com">alexandre.anf@gmail.com</a></p>
-            <p><i class='bx bxl-linkedin-square'></i> <a href="https://www.linkedin.com/in/alexandrearnoni" target="_blank">LinkedIn</a></p>
-            <p><i class='bx bxl-github'></i> <a href="https://github.com/alexarnoni" target="_blank">GitHub</a></p>
+            <p><i class='bx bxl-linkedin-square'></i> <a href="https://www.linkedin.com/in/alexandrearnoni" target="_blank" rel="noopener noreferrer">LinkedIn</a></p>
+            <p><i class='bx bxl-github'></i> <a href="https://github.com/alexarnoni" target="_blank" rel="noopener noreferrer">GitHub</a></p>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -1,146 +1,182 @@
-// === THEME: clona container claro para dark e configura toggle ===
-const container = document.querySelector('.container');
-const cloneContainer = container.cloneNode(true);
-cloneContainer.id = 'dark-container';
-document.body.appendChild(cloneContainer);
-cloneContainer.classList.remove('active');
+// === Tema ================================================================
+const body = document.body;
+const themeToggle = document.querySelector('#theme-toggle');
+const themeIcon = themeToggle?.querySelector('i');
+const prefersDarkScheme = typeof window.matchMedia === 'function'
+  ? window.matchMedia('(prefers-color-scheme: dark)')
+  : null;
+const THEME_STORAGE_KEY = 'alexarnoni-theme';
 
-// Sincroniza imagem (se necessário)
-const homeImgSrc = container.querySelector('.home-img img')?.getAttribute('src');
-const darkContainerImg = cloneContainer.querySelector('.home-img img');
-if (homeImgSrc && darkContainerImg) darkContainerImg.setAttribute('src', homeImgSrc);
-
-const toggleIcons = document.querySelectorAll('.toggle-icon');
-const iconEls = document.querySelectorAll('.toggle-icon i');
-const darkContainer = document.querySelector('#dark-container');
-
-toggleIcons.forEach(toggle => {
-  toggle.addEventListener('click', () => {
-    toggle.classList.add('disabled');
-    setTimeout(() => toggle.classList.remove('disabled'), 1500);
-
-    iconEls.forEach(icon => icon.classList.toggle('bx-sun'));
-    container.classList.toggle('active');
-    darkContainer.classList.toggle('active');
-  });
-});
-
-// Ativa dark-mode por padrão (opcional)
-document.querySelector('#container').classList.remove('active');
-document.querySelector('#dark-container').classList.add('active');
-
-// === NAV: scroll spy + botão topo (usa sempre o container ATIVO) ===
-function getActiveContainer() {
-  return document.querySelector('#dark-container.active') || document.querySelector('#container.active');
+let storage = null;
+try {
+  storage = window.localStorage;
+} catch (error) {
+  storage = null;
 }
 
+let storedTheme = null;
+if (storage) {
+  storedTheme = storage.getItem(THEME_STORAGE_KEY);
+}
+let userPreference = storedTheme || null;
+
+function applyTheme(theme, { savePreference = false } = {}) {
+  const isDark = theme === 'dark';
+  body.classList.toggle('dark-mode', isDark);
+
+  if (themeToggle) {
+    themeToggle.setAttribute('aria-pressed', String(isDark));
+    themeToggle.setAttribute('aria-label', isDark ? 'Ativar tema claro' : 'Ativar tema escuro');
+  }
+
+  if (themeIcon) {
+    themeIcon.classList.toggle('bx-sun', isDark);
+    themeIcon.classList.toggle('bx-moon', !isDark);
+  }
+
+  if (savePreference) {
+    userPreference = theme;
+    if (storage) {
+      storage.setItem(THEME_STORAGE_KEY, theme);
+    }
+  }
+}
+
+applyTheme(userPreference || (prefersDarkScheme?.matches ? 'dark' : 'light'));
+
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    const nextTheme = body.classList.contains('dark-mode') ? 'light' : 'dark';
+    applyTheme(nextTheme, { savePreference: true });
+  });
+}
+
+if (prefersDarkScheme) {
+  const preferenceListener = event => {
+    if (!userPreference) {
+      applyTheme(event.matches ? 'dark' : 'light');
+    }
+  };
+
+  if (typeof prefersDarkScheme.addEventListener === 'function') {
+    prefersDarkScheme.addEventListener('change', preferenceListener);
+  } else if (typeof prefersDarkScheme.addListener === 'function') {
+    prefersDarkScheme.addListener(preferenceListener);
+  }
+}
+
+// === Navegação e botão topo =============================================
+const sections = Array.from(document.querySelectorAll('main section'));
+const navLinks = Array.from(document.querySelectorAll('.navbar a[href^="#"]'));
+const btnTopo = document.querySelector('.btn-topo');
+const header = document.querySelector('.header');
+
 function handleScroll() {
-  const active = getActiveContainer();
-  if (!active) return;
+  if (!sections.length) return;
 
-  const sections = active.querySelectorAll('section');
-  const navLinks = active.querySelectorAll('.navbar a');
-  const btnTopo = active.querySelector('.btn-topo');
+  const headerOffset = header ? header.offsetHeight + 20 : 100;
+  let currentSectionId = sections[0].id || '';
 
-  let current = '';
   sections.forEach(section => {
-    const sectionTop = section.offsetTop - 80;
-    const sectionHeight = section.clientHeight;
-    if (window.scrollY >= sectionTop && window.scrollY < sectionTop + sectionHeight) {
-      current = section.getAttribute('id');
+    const sectionTop = section.offsetTop - headerOffset;
+    if (window.scrollY >= sectionTop) {
+      currentSectionId = section.id || currentSectionId;
     }
   });
 
   navLinks.forEach(link => {
-    link.classList.toggle('active', link.getAttribute('href') === `#${current}`);
+    const target = link.getAttribute('href')?.slice(1);
+    link.classList.toggle('active', target === currentSectionId);
   });
 
   if (btnTopo) {
-    if (window.scrollY > 300) btnTopo.classList.remove('hidden');
-    else btnTopo.classList.add('hidden');
+    btnTopo.classList.toggle('hidden', window.scrollY < 300);
   }
 }
 
 window.addEventListener('scroll', handleScroll);
-handleScroll(); // inicial
+handleScroll();
 
-// === Fade-in animation com IntersectionObserver (observa os dois containers) ===
+// === Animações de entrada ===============================================
 const observer = new IntersectionObserver(entries => {
   entries.forEach(entry => {
-    if (entry.isIntersecting) entry.target.classList.add('visible');
+    if (entry.isIntersecting) {
+      entry.target.classList.add('visible');
+    }
   });
-}, { threshold: 0.1 });
+}, { threshold: 0.15 });
 
-document.querySelectorAll('section').forEach(section => observer.observe(section));
+sections.forEach(section => observer.observe(section));
 
-// === Menu hambúrguer (claro e escuro) ===
+// === Menu hambúrguer ====================================================
 document.querySelectorAll('.menu-toggle').forEach(toggle => {
-  const navLinks = toggle.closest('.navbar')?.querySelector('.nav-links');
-  if (!navLinks) return;
+  const navLinksEl = toggle.closest('.navbar')?.querySelector('.nav-links');
+  if (!navLinksEl) return;
 
   toggle.addEventListener('click', () => {
-    const isOpen = navLinks.classList.toggle('open');
+    const isOpen = navLinksEl.classList.toggle('open');
     toggle.setAttribute('aria-expanded', String(isOpen));
   });
 
   toggle.setAttribute('aria-expanded', 'false');
 
-  navLinks.querySelectorAll('a').forEach(link => {
+  navLinksEl.querySelectorAll('a').forEach(link => {
     link.addEventListener('click', () => {
-      if (navLinks.classList.contains('open')) {
-        navLinks.classList.remove('open');
+      if (navLinksEl.classList.contains('open')) {
+        navLinksEl.classList.remove('open');
         toggle.setAttribute('aria-expanded', 'false');
       }
     });
   });
 });
 
-// === DROPDOWN (Download CV): hover no desktop + clique no mobile ===
-// CSS já abre no :hover; aqui tratamos clique/touch, acessibilidade e fechar fora.
+// === Dropdown (Download CV) ============================================
 document.querySelectorAll('.dropdown .btn').forEach(btn => {
   const dropdown = btn.closest('.dropdown');
   if (!dropdown) return;
 
-  // Acessibilidade
   btn.setAttribute('aria-haspopup', 'true');
   btn.setAttribute('aria-expanded', 'false');
 
-  btn.addEventListener('click', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
+  btn.addEventListener('click', event => {
+    event.preventDefault();
+    event.stopPropagation();
 
     const isOpen = dropdown.classList.toggle('open');
     btn.setAttribute('aria-expanded', String(isOpen));
 
-    // Fecha outros dropdowns
     document.querySelectorAll('.dropdown').forEach(other => {
       if (other !== dropdown) {
         other.classList.remove('open');
         const otherBtn = other.querySelector('.btn');
-        if (otherBtn) otherBtn.setAttribute('aria-expanded', 'false');
+        if (otherBtn) {
+          otherBtn.setAttribute('aria-expanded', 'false');
+        }
       }
     });
   });
 });
 
-// Fecha dropdown ao clicar fora
-window.addEventListener('click', (e) => {
+window.addEventListener('click', event => {
   document.querySelectorAll('.dropdown.open').forEach(drop => {
-    if (!drop.contains(e.target)) {
+    if (!drop.contains(event.target)) {
       drop.classList.remove('open');
       const btn = drop.querySelector('.btn');
-      if (btn) btn.setAttribute('aria-expanded', 'false');
+      if (btn) {
+        btn.setAttribute('aria-expanded', 'false');
+      }
     }
   });
 });
 
-// Fecha dropdown com ESC
-window.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape') {
+window.addEventListener('keydown', event => {
+  if (event.key === 'Escape') {
     document.querySelectorAll('.dropdown.open').forEach(drop => {
       drop.classList.remove('open');
       const btn = drop.querySelector('.btn');
-      if (btn) btn.setAttribute('aria-expanded', 'false');
+      if (btn) {
+        btn.setAttribute('aria-expanded', 'false');
+      }
     });
   }
 });

--- a/style.css
+++ b/style.css
@@ -10,13 +10,42 @@ html {
 }
 
 :root {
-    --cor-clara: #f1e6ce;
-    --cor-escura: #12100e;
-    --destaque: #d39652;
-    --destaque-claro: #d9a861;
-    --texto-claro: #3a2f1d;
-    --marrom-nome: #5d3b23;
-    --ambar-claro: #e3b07f;
+    --bg-color: #f1e6ce;
+    --surface-color: #f1e6ce;
+    --text-color: #3a2f1d;
+    --heading-color: #5d3b23;
+    --accent-color: #d39652;
+    --accent-light: #d9a861;
+    --button-text-color: #1b1b1b;
+    --card-shadow: 0 0 10px rgba(0, 0, 0, 0.08);
+    --card-shadow-hover: 0 8px 20px rgba(0, 0, 0, 0.15);
+    --header-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    --toggle-color: #3a2f1d;
+    --btn-topo-bg: #d39652;
+    --btn-topo-hover: #d9a861;
+    --btn-topo-color: #ffffff;
+    --dropdown-bg: #f1e6ce;
+    --dropdown-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+    --dropdown-link-color: #3a2f1d;
+}
+
+body.dark-mode {
+    --bg-color: #12100e;
+    --surface-color: #12100e;
+    --text-color: #f1e6ce;
+    --heading-color: #f1e6ce;
+    --accent-color: #d9a861;
+    --accent-light: #e3b07f;
+    --card-shadow: 0 0 10px rgba(255, 255, 255, 0.08);
+    --card-shadow-hover: 0 8px 20px rgba(0, 0, 0, 0.35);
+    --header-shadow: 0 2px 6px rgba(255, 255, 255, 0.05);
+    --toggle-color: #f1e6ce;
+    --btn-topo-bg: #d9a861;
+    --btn-topo-hover: #ffffff;
+    --btn-topo-color: #1b1b1b;
+    --dropdown-bg: #12100e;
+    --dropdown-shadow: 0 8px 16px rgba(255, 255, 255, 0.08);
+    --dropdown-link-color: #f1e6ce;
 }
 
 * {
@@ -28,15 +57,16 @@ html {
 }
 
 body {
-    background-color: var(--cor-clara);
-    color: var(--texto-claro);
-    transition: background-color 0.5s ease, color 0.5s ease;    
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .container {
-    background: var(--cor-clara);
-    color: var(--texto-claro);
+    background: var(--bg-color);
+    color: var(--text-color);
     position: relative;
+    transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .header {
@@ -49,20 +79,16 @@ body {
     align-items: center;
     justify-content: space-between;
     z-index: 100;
-    background-color: var(--cor-clara);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-}
-
-#dark-container .header {
-    box-shadow: 0 2px 6px rgba(255, 255, 255, 0.05);
-    background-color: var(--cor-escura);
+    background-color: var(--surface-color);
+    box-shadow: var(--header-shadow);
+    transition: background-color 0.4s ease, box-shadow 0.4s ease;
 }
 
 .logo {
     display: flex;
     align-items: center;
     font-size: 32px;
-    color: var(--marrom-nome);
+    color: var(--heading-color);
     font-family: 'SuffolkPunch', serif;
     margin-right: auto;
     gap: 10px;
@@ -73,35 +99,33 @@ body {
     height: 28px;
 }
 
-#dark-container .logo {
-    color: var(--cor-clara);
-}
-
 .navbar a {
     font-size: 18px;
-    color: var(--texto-claro);
-    transition: .5s;
+    color: var(--text-color);
+    transition: color 0.3s ease;
 }
 
 .navbar a:hover,
 .navbar a.active {
-    color: var(--destaque);
+    color: var(--accent-color);
 }
 
-.toggle-icon {
+.toggle-button {
     font-size: 24px;
     cursor: pointer;
     background: transparent;
-    color: var(--texto-claro);
+    border: none;
+    color: var(--toggle-color);
     z-index: 999;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: color 0.4s ease, transform 0.3s ease;
 }
 
-.toggle-icon.disabled {
-    pointer-events: none;
-}
-
-#dark-container .toggle-icon {
-    color: var(--cor-clara);
+.toggle-button:hover {
+    transform: scale(1.05);
 }
 
 .nav-controls {
@@ -138,7 +162,7 @@ section.visible {
 .home-content h1 {
     font-size: 56px;
     font-family: 'SuffolkPunch', serif;
-    color: var(--marrom-nome);
+    color: var(--heading-color);
 }
 
 .home-content h3 {
@@ -147,7 +171,7 @@ section.visible {
 }
 
 .home-content h3 span {
-    color: var(--destaque);
+    color: var(--accent-color);
     font-weight: 600;
 }
 
@@ -162,39 +186,39 @@ section.visible {
     align-items: center;
     width: 40px;
     height: 40px;
-    border: 2px solid var(--destaque);
+    border: 2px solid var(--accent-color);
     border-radius: 50%;
     font-size: 20px;
-    color: var(--destaque);
+    color: var(--accent-color);
     margin: 5px 15px 25px 0;
-    transition: .5s;
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .social-media a:hover {
-    background: var(--destaque);
+    background: var(--accent-color);
     color: #fff;
 }
 
-a:focus, button:focus, .toggle-icon:focus {
-    outline: 2px dashed var(--destaque);
+a:focus, button:focus, .toggle-button:focus {
+    outline: 2px dashed var(--accent-color);
     outline-offset: 4px;
 }
 
 .btn {
     display: inline-block;
     padding: 11px 32px;
-    background: var(--destaque-claro);
-    border: 2px solid var(--destaque-claro);
+    background: var(--accent-light);
+    border: 2px solid var(--accent-light);
     border-radius: 40px;
     font-size: 16px;
-    color: #1b1b1b;
+    color: var(--button-text-color);
     font-weight: 600;
-    transition: .5s;
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .btn:hover {
     background: transparent;
-    color: var(--destaque-claro);
+    color: var(--accent-light);
 }
 
 .home-img {
@@ -212,71 +236,6 @@ a:focus, button:focus, .toggle-icon:focus {
     object-fit: contain;
 }
 
-#dark-container {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    background: var(--cor-escura);
-    color: var(--cor-clara);
-}
-
-#dark-container .logo,
-#dark-container .navbar a {
-    color: var(--cor-clara);
-}
-
-#dark-container .menu-toggle {
-  color: var(--cor-clara);
-}
-
-#dark-container .navbar a:hover,
-#dark-container .navbar a.active {
-    color: var(--destaque-claro);
-}
-
-#dark-container .home-content h1 {
-    color: var(--cor-clara); 
-}
-
-#dark-container .home-content h3 span {
-    color: var(--destaque-claro);
-}
-
-#dark-container .social-media a {
-    border-color: var(--destaque-claro);
-    color: var(--destaque-claro);
-}
-
-#dark-container .social-media a:hover {
-    background: var(--destaque-claro);
-    color: #1b1b1b;
-}
-
-#dark-container .btn {
-    background: var(--destaque-claro);
-    border-color: var(--destaque-claro);
-    color: #1b1b1b;
-}
-
-#dark-container .btn:hover {
-    background: transparent;
-    color: var(--destaque-claro);
-}
-
-#container,
-#dark-container {
-    clip-path: circle(0% at 0 0);
-    transition-delay: 1.5s;
-}
-
-.active#container,
-.active#dark-container {
-    z-index: 1;
-    clip-path: circle(150% at 0 0);
-    transition: 1.5s cubic-bezier(0.645, 0.045, 0.355, 1);
-}
-
 .section-container {
     max-width: 960px;
     margin: 0 auto;
@@ -287,22 +246,14 @@ a:focus, button:focus, .toggle-icon:focus {
     font-size: 28px;
     font-weight: bold;
     margin-bottom: 20px;
-    color: var(--marrom-nome);
+    color: var(--heading-color);
 }
 
 .section-text {
     font-size: 16px;
     line-height: 1.6;
-    color: var(--texto-claro);
+    color: var(--text-color);
     margin-bottom: 40px;
-}
-
-#dark-container .section-title {
-    color: var(--destaque-claro);
-}
-
-#dark-container .section-text {
-    color: var(--cor-clara);
 }
 
 .project-grid {
@@ -319,13 +270,13 @@ a:focus, button:focus, .toggle-icon:focus {
     flex-direction: column;
     align-items: center;
     gap: 15px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--card-shadow);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .project-card:hover {
     transform: translateY(-5px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--card-shadow-hover);
 }
 
 .project-img {
@@ -346,26 +297,14 @@ a:focus, button:focus, .toggle-icon:focus {
 
 .project-info h3 {
     font-size: 20px;
-    color: var(--marrom-nome);
+    color: var(--heading-color);
     margin-bottom: 5px;
 }
 
 .project-info p {
     font-size: 15px;
-    color: var(--texto-claro);
+    color: var(--text-color);
     margin-bottom: 15px;
-}
-
-#dark-container .project-info h3 {
-    color: var(--destaque-claro);
-}
-
-#dark-container .project-info p {
-    color: var(--cor-clara);
-}
-
-#dark-container .project-card {
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.08);
 }
 
 .contact-info {
@@ -380,45 +319,41 @@ a:focus, button:focus, .toggle-icon:focus {
 
 .contact-info i {
     margin-right: 8px;
-    color: var(--destaque);
+    color: var(--accent-color);
     font-size: 20px;
     vertical-align: middle;
 }
 
 .contact-info a {
-    color: var(--texto-claro);
+    color: var(--text-color);
     font-weight: 500;
-    transition: color 0.3s;
+    transition: color 0.3s ease;
 }
 
 .contact-info a:hover {
-    color: var(--destaque);
-}
-
-#dark-container .contact-info a {
-    color: var(--cor-clara);
-}
-
-#dark-container .contact-info a:hover {
-    color: var(--destaque-claro);
+    color: var(--accent-color);
 }
 
 .btn-topo {
     position: fixed;
     bottom: 30px;
     right: 30px;
-    background-color: var(--destaque);
-    color: #fff;
+    background-color: var(--btn-topo-bg);
+    color: var(--btn-topo-color);
     border: none;
     border-radius: 50%;
     padding: 12px 14px;
     font-size: 24px;
     cursor: pointer;
     z-index: 999;
-    transition: all 0.3s ease;
+    transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
     opacity: 1;
     visibility: visible;
+}
+
+.btn-topo:hover {
+    background-color: var(--btn-topo-hover);
 }
 
 .btn-topo.hidden {
@@ -427,23 +362,14 @@ a:focus, button:focus, .toggle-icon:focus {
     pointer-events: none;
 }
 
-#dark-container .btn-topo {
-    background-color: var(--destaque-claro);
-    color: #1b1b1b;
-}
-
-#dark-container .btn-topo:hover {
-    background-color: #fff;
-}
-
 .menu-toggle {
   display: none;
   background: none;
   border: none;
   font-size: 28px;
   cursor: pointer;
-  color: var(--texto-claro);
-  margin-top: -10px; 
+  color: var(--text-color);
+  margin-top: -10px;
   line-height: 1;
   padding: 0;
   align-self: center;
@@ -483,10 +409,10 @@ a:focus, button:focus, .toggle-icon:focus {
         position: absolute;
         top: 80px;
         right: 30px;
-        background-color: var(--cor-clara);
+        background-color: var(--dropdown-bg);
         padding: 15px;
         border-radius: 10px;
-        box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+        box-shadow: var(--dropdown-shadow);
         z-index: 999;
         opacity: 0;
         transform: translateY(-10px);
@@ -498,10 +424,6 @@ a:focus, button:focus, .toggle-icon:focus {
         opacity: 1;
         transform: translateY(0);
         pointer-events: auto;
-    }
-
-    #dark-container .nav-links {
-        background-color: var(--cor-escura);
     }
 
     .nav-links a {
@@ -588,8 +510,8 @@ a:focus, button:focus, .toggle-icon:focus {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: var(--cor-clara);
-  box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+  background-color: var(--dropdown-bg);
+  box-shadow: var(--dropdown-shadow);
   border-radius: 10px;
   min-width: 220px;
   padding: 8px 0;
@@ -598,7 +520,7 @@ a:focus, button:focus, .toggle-icon:focus {
   visibility: hidden;
   transform: translateY(4px);
   pointer-events: none;
-  transition: opacity .18s ease, transform .18s ease, visibility .18s ease;
+  transition: opacity .18s ease, transform .18s ease, visibility .18s ease, background-color 0.3s ease;
   z-index: 99;
 }
 
@@ -615,32 +537,17 @@ a:focus, button:focus, .toggle-icon:focus {
 /* Links */
 .dropdown-content a {
   display: block;
-  color: var(--texto-claro) !important;
+  color: var(--dropdown-link-color) !important;
   padding: 10px 20px;
   text-decoration: none !important;
-  transition: background-color .2s ease;
+  transition: background-color .2s ease, color 0.2s ease;
   font-weight: 500;
   font-family: 'Poppins', sans-serif;
 }
 
 .dropdown-content a:hover {
-  background-color: var(--destaque-claro);
-  color: #1b1b1b !important;
-}
-
-/* === DARK MODE === */
-#dark-container .dropdown-content {
-  background-color: var(--cor-escura);
-  box-shadow: 0 8px 16px rgba(255,255,255,0.08);
-}
-
-#dark-container .dropdown-content a {
-  color: var(--cor-clara) !important;
-}
-
-#dark-container .dropdown-content a:hover {
-  background-color: var(--destaque-claro);
-  color: #1b1b1b !important;
+  background-color: var(--accent-light);
+  color: var(--button-text-color) !important;
 }
 
 .skills-grid {
@@ -653,7 +560,7 @@ a:focus, button:focus, .toggle-icon:focus {
 .skills-col h3 {
   font-size: 18px;
   margin-bottom: 15px;
-  color: var(--marrom-nome);
+  color: var(--heading-color);
 }
 
 .skills-col ul {
@@ -666,11 +573,12 @@ a:focus, button:focus, .toggle-icon:focus {
   font-size: 15px;
   display: flex;
   align-items: center;
+  color: var(--text-color);
 }
 
 .skills-col ul li i {
   font-size: 18px;
-  color: var(--destaque);
+  color: var(--accent-color);
   margin-right: 8px;
   transition: transform 0.2s ease;
 }
@@ -679,14 +587,3 @@ a:focus, button:focus, .toggle-icon:focus {
   transform: scale(1.2);
 }
 
-#dark-container .skills-col h3 {
-  color: var(--destaque-claro);
-}
-
-#dark-container .skills-col ul li {
-  color: var(--cor-clara);
-}
-
-#dark-container .skills-col ul li i {
-  color: var(--destaque-claro);
-}


### PR DESCRIPTION
## Summary
- replace the duplicated container toggle with a single accessible theme button that toggles `body.dark-mode` and persists the choice
- rebuild the stylesheet around shared CSS variables so light/dark themes transition smoothly without duplicate selectors
- add `rel="noopener noreferrer"` to every external link opened in a new tab

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c84a04aa28832cb130783ea7378818