### PR TITLE
Add radial mask animation to theme toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,8 +44,34 @@ function applyTheme(theme, { savePreference = false } = {}) {
 
 applyTheme(userPreference || (prefersDarkScheme?.matches ? 'dark' : 'light'));
 
+const handleThemeTransitionEnd = event => {
+  if (!body.classList.contains('theme-transition')) return;
+  if (event.target !== body) return;
+  if (event.type === 'transitionend' && event.propertyName !== 'clip-path') return;
+
+  body.classList.remove('theme-transition');
+};
+
+body.addEventListener('transitionend', handleThemeTransitionEnd);
+body.addEventListener('animationend', handleThemeTransitionEnd);
+
 if (themeToggle) {
-  themeToggle.addEventListener('click', () => {
+  themeToggle.addEventListener('click', event => {
+    const rect = themeToggle.getBoundingClientRect();
+    const isKeyboardTrigger = event.detail === 0 && event.clientX === 0 && event.clientY === 0;
+    const clickX = isKeyboardTrigger ? rect.left + rect.width / 2 : event.clientX;
+    const clickY = isKeyboardTrigger ? rect.top + rect.height / 2 : event.clientY;
+
+    body.style.setProperty('--click-x', `${clickX}px`);
+    body.style.setProperty('--click-y', `${clickY}px`);
+
+    if (body.classList.contains('theme-transition')) {
+      body.classList.remove('theme-transition');
+      void body.offsetWidth;
+    }
+
+    body.classList.add('theme-transition');
+
     const nextTheme = body.classList.contains('dark-mode') ? 'light' : 'dark';
     applyTheme(nextTheme, { savePreference: true });
   });

--- a/style.css
+++ b/style.css
@@ -27,6 +27,8 @@ html {
     --dropdown-bg: #f1e6ce;
     --dropdown-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
     --dropdown-link-color: #3a2f1d;
+    --click-x: 50%;
+    --click-y: 50%;
 }
 
 body.dark-mode {
@@ -60,6 +62,25 @@ body {
     background-color: var(--bg-color);
     color: var(--text-color);
     transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    background: var(--bg-color);
+    clip-path: circle(0% at var(--click-x) var(--click-y));
+    opacity: 0;
+    pointer-events: none;
+    transition: clip-path 0.6s ease, opacity 0.4s ease;
+    z-index: 9999;
+}
+
+body.theme-transition::before {
+    opacity: 1;
+    clip-path: circle(150% at var(--click-x) var(--click-y));
 }
 
 .container {


### PR DESCRIPTION
## Summary
- add a body pseudo-element mask that animates with clip-path to reveal the new theme from the click position
- capture theme toggle click coordinates and store them as CSS variables for the transition
- manage the temporary theme-transition class lifecycle to reset the animation after each toggle

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8528c7fb8832c8bd55d9b47195e07