### PR TITLE
Add radial mask animation to theme toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,9 +27,11 @@ html {
     --dropdown-bg: #f1e6ce;
     --dropdown-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
     --dropdown-link-color: #3a2f1d;
+    --click-x: 50%;
+    --click-y: 50%;
 }
 
-body.dark-mode {
+.dark-mode {
     --bg-color: #12100e;
     --surface-color: #12100e;
     --text-color: #f1e6ce;
@@ -48,6 +50,14 @@ body.dark-mode {
     --dropdown-link-color: #f1e6ce;
 }
 
+/* Cloned container used during theme transition */
+.theme-clone {
+    position: fixed;
+    inset: 0;
+    z-index: 9998;
+    pointer-events: none;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -60,6 +70,25 @@ body {
     background-color: var(--bg-color);
     color: var(--text-color);
     transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    background: var(--bg-color);
+    clip-path: circle(0% at var(--click-x) var(--click-y));
+    opacity: 0;
+    pointer-events: none;
+    transition: clip-path 0.6s ease, opacity 0.4s ease;
+    z-index: 9999;
+}
+
+body.theme-transition::before {
+    opacity: 1;
+    clip-path: circle(150% at var(--click-x) var(--click-y));
 }
 
 .container {


### PR DESCRIPTION
## Summary
- add a body pseudo-element mask that animates with clip-path to reveal the new theme from the click position
- capture theme toggle click coordinates and store them as CSS variables for the transition
- manage the temporary theme-transition class lifecycle to reset the animation after each toggle
- clone the current container to preserve the previous theme during the mask animation

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8528c7fb8832c8bd55d9b47195e07